### PR TITLE
Capability to cut error source file path to desired deep

### DIFF
--- a/e2h_example_test.go
+++ b/e2h_example_test.go
@@ -22,9 +22,9 @@ func ExampleEnhancedError() {
 
 	fmt.Printf("Just as Error => %s\n", err)
 
-	fmt.Printf("Full info Pretty =>\n%s", e2h.FormatPretty(err))
+	fmt.Printf("Full info Pretty =>\n%s", e2h.FormatPretty(err, "github.com"))
 
-	fmt.Printf("Full info JSON =>\n\t%s\n", e2h.FormatJSON(err))
+	fmt.Printf("Full info JSON =>\n\t%s\n", e2h.FormatJSON(err, "github.com"))
 
 	// Output:
 	// Just Cause => foo
@@ -32,12 +32,12 @@ func ExampleEnhancedError() {
 	// Full info Pretty =>
 	// - This call adds stack information:
 	//   github.com/cdleo/go-e2h_test.ExampleEnhancedError
-	//   	/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_example_test.go:19
+	//   	github.com/cdleo/go-e2h/e2h_example_test.go:19
 	// - This call wraps the GO error and adds this context and other helpful information:
 	//   github.com/cdleo/go-e2h_test.bar
-	//   	/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_example_test.go:14
+	//   	github.com/cdleo/go-e2h/e2h_example_test.go:14
 	// - foo
 	// Full info JSON =>
-	//	{"error":"foo: This call wraps the GO error and adds this context and other helpful information","stack_trace":[{"func":"github.com/cdleo/go-e2h_test.ExampleEnhancedError","caller":"/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_example_test.go:19","context":"This call adds stack information"},{"func":"github.com/cdleo/go-e2h_test.bar","caller":"/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_example_test.go:14","context":"This call wraps the GO error and adds this context and other helpful information"}]}
+	//	{"error":"foo: This call wraps the GO error and adds this context and other helpful information","stack_trace":[{"func":"github.com/cdleo/go-e2h_test.ExampleEnhancedError","caller":"github.com/cdleo/go-e2h/e2h_example_test.go:19","context":"This call adds stack information"},{"func":"github.com/cdleo/go-e2h_test.bar","caller":"github.com/cdleo/go-e2h/e2h_example_test.go:14","context":"This call wraps the GO error and adds this context and other helpful information"}]}
 
 }

--- a/e2h_test.go
+++ b/e2h_test.go
@@ -24,7 +24,7 @@ func TestEnhancedError_FormatStdError_Pretty(t *testing.T) {
 	// Setup
 	stdErr := fmt.Errorf("This is a standard error")
 
-	output := e2h.FormatPretty(stdErr)
+	output := e2h.FormatPretty(stdErr, "")
 
 	require.Equal(t, output, "This is a standard error")
 }
@@ -34,7 +34,7 @@ func TestEnhancedError_FormatStdError_JSON(t *testing.T) {
 	// Setup
 	stdErr := fmt.Errorf("This is a standard error")
 
-	outputJSON := e2h.FormatJSON(stdErr)
+	outputJSON := e2h.FormatJSON(stdErr, "")
 
 	require.Equal(t, string(outputJSON[:]), "{\"error\":\"This is a standard error\",\"stack_trace\":[]}")
 }
@@ -54,9 +54,9 @@ func TestEnhancedError_FormatEnhError_Pretty(t *testing.T) {
 	// Setup
 	enhancedErr := e2h.Trace(fmt.Errorf("This is a standard error"), "Error wrapped with additional info")
 
-	output := e2h.FormatPretty(enhancedErr)
+	output := e2h.FormatPretty(enhancedErr, "github.com")
 
-	require.Equal(t, output, "- Error wrapped with additional info:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_FormatEnhError_Pretty\n  \t/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_test.go:55\n- This is a standard error\n")
+	require.Equal(t, output, "- Error wrapped with additional info:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_FormatEnhError_Pretty\n  \tgithub.com/cdleo/go-e2h/e2h_test.go:55\n- This is a standard error\n")
 }
 
 func TestEnhancedError_FormatEnhError_JSON(t *testing.T) {
@@ -64,9 +64,9 @@ func TestEnhancedError_FormatEnhError_JSON(t *testing.T) {
 	// Setup
 	enhancedErr := e2h.Trace(fmt.Errorf("This is a standard error"), "Error wrapped with additional info")
 
-	outputJSON := e2h.FormatJSON(enhancedErr)
+	outputJSON := e2h.FormatJSON(enhancedErr, "github.com")
 
-	require.Equal(t, string(outputJSON[:]), "{\"error\":\"This is a standard error: Error wrapped with additional info\",\"stack_trace\":[{\"func\":\"github.com/cdleo/go-e2h_test.TestEnhancedError_FormatEnhError_JSON\",\"caller\":\"/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_test.go:65\",\"context\":\"Error wrapped with additional info\"}]}")
+	require.Equal(t, string(outputJSON[:]), "{\"error\":\"This is a standard error: Error wrapped with additional info\",\"stack_trace\":[{\"func\":\"github.com/cdleo/go-e2h_test.TestEnhancedError_FormatEnhError_JSON\",\"caller\":\"github.com/cdleo/go-e2h/e2h_test.go:65\",\"context\":\"Error wrapped with additional info\"}]}")
 }
 
 func TestEnhancedError_EnhError_StackTraces(t *testing.T) {
@@ -76,7 +76,7 @@ func TestEnhancedError_EnhError_StackTraces(t *testing.T) {
 	enhancedErr = e2h.Tracef(enhancedErr, "This is the %dnd. stack level", 2)
 	enhancedErr = e2h.TraceA(enhancedErr)
 
-	output := e2h.FormatPretty(enhancedErr)
+	output := e2h.FormatPretty(enhancedErr, "github.com")
 
-	require.Equal(t, output, "  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \t/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_test.go:77\n- This is the 2nd. stack level:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \t/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_test.go:76\n- Error wrapped with additional info:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \t/home/christian/sources/src/github.com/cdleo/go-e2h/e2h_test.go:75\n- This is a standard error\n")
+	require.Equal(t, output, "  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \tgithub.com/cdleo/go-e2h/e2h_test.go:77\n- This is the 2nd. stack level:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \tgithub.com/cdleo/go-e2h/e2h_test.go:76\n- Error wrapped with additional info:\n  github.com/cdleo/go-e2h_test.TestEnhancedError_EnhError_StackTraces\n  \tgithub.com/cdleo/go-e2h/e2h_test.go:75\n- This is a standard error\n")
 }


### PR DESCRIPTION
Capability to cut error source file path to desired deep.
This feature simplifies the error log reading, avoiding the custom users's path